### PR TITLE
Change setShimmeringSpeed's param type to match property type

### DIFF
--- a/FBShimmering/FBShimmeringLayer.m
+++ b/FBShimmering/FBShimmeringLayer.m
@@ -183,7 +183,7 @@ static CAAnimation *shimmer_slide_finish(CAAnimation *a)
   }
 }
 
-- (void)setShimmeringSpeed:(float)speed
+- (void)setShimmeringSpeed:(CGFloat)speed
 {
   if (speed != _shimmeringSpeed) {
     _shimmeringSpeed = speed;


### PR DESCRIPTION
`shimmeringSpeed` is defined to be a CGFloat but the the setter takes a float. On arm64 CGFloat is defined to be a double, which raises a compiler warning.
