### PR TITLE
Remove extra ';' outside of function macros

### DIFF
--- a/FBShimmering/FBShimmeringView.m
+++ b/FBShimmering/FBShimmeringView.m
@@ -38,14 +38,14 @@
   LAYER_ACCESSOR (accessor, ctype) \
   LAYER_MUTATOR (mutator, ctype)
 
-LAYER_RW_PROPERTY(isShimmering, setShimmering:, BOOL);
-LAYER_RW_PROPERTY(shimmeringPauseDuration, setShimmeringPauseDuration:, CFTimeInterval);
-LAYER_RW_PROPERTY(shimmeringOpacity, setShimmeringOpacity:, CGFloat);
-LAYER_RW_PROPERTY(shimmeringSpeed, setShimmeringSpeed:, CGFloat);
-LAYER_RW_PROPERTY(shimmeringHighlightWidth, setShimmeringHighlightWidth:, CGFloat);
-LAYER_ACCESSOR(shimmeringFadeTime, CFTimeInterval);
-LAYER_RW_PROPERTY(shimmeringBeginFadeDuration, setShimmeringBeginFadeDuration:, CFTimeInterval);
-LAYER_RW_PROPERTY(shimmeringEndFadeDuration, setShimmeringEndFadeDuration:, CFTimeInterval);
+LAYER_RW_PROPERTY(isShimmering, setShimmering:, BOOL)
+LAYER_RW_PROPERTY(shimmeringPauseDuration, setShimmeringPauseDuration:, CFTimeInterval)
+LAYER_RW_PROPERTY(shimmeringOpacity, setShimmeringOpacity:, CGFloat)
+LAYER_RW_PROPERTY(shimmeringSpeed, setShimmeringSpeed:, CGFloat)
+LAYER_RW_PROPERTY(shimmeringHighlightWidth, setShimmeringHighlightWidth:, CGFloat)
+LAYER_ACCESSOR(shimmeringFadeTime, CFTimeInterval)
+LAYER_RW_PROPERTY(shimmeringBeginFadeDuration, setShimmeringBeginFadeDuration:, CFTimeInterval)
+LAYER_RW_PROPERTY(shimmeringEndFadeDuration, setShimmeringEndFadeDuration:, CFTimeInterval)
 
 - (void)setContentView:(UIView *)contentView
 {


### PR DESCRIPTION
This may be a bit pedantic, but because `LAYER_ACCESSOR`, `LAYER_MUTATOR` and `LAYER_RW_PROPERTY` are simply generating setter/getter methods, there is no need to terminate their use with a semicolon.

![Screenshot](https://f.cloud.github.com/assets/647626/2418129/956c9f32-ab37-11e3-8462-69d29f8056de.png)
