### PR TITLE
layoutSubviews never gets called on FBShimmeringView

### DIFF
--- a/FBShimmering/FBShimmeringLayer.m
+++ b/FBShimmering/FBShimmeringLayer.m
@@ -246,6 +246,7 @@ static CAAnimation *shimmer_slide_finish(CAAnimation *a)
 
 - (void)layoutSublayers
 {
+  [super layoutSublayers];
   CGRect r = self.bounds;
   _contentLayer.anchorPoint = CGPointMake(0.5, 0.5);
   _contentLayer.bounds = r;


### PR DESCRIPTION
The issue is related to missing `[super layoutSublayers]` line that was added in this pull request. 

The missing line resulted in layout not updating when shimmering view bounds changes. This result in auto layout failing to adjust size for `contentView` when shimmering bounds changed. Moreover `layoutSubviews` never got called (which is the actual reason for previous issue). 

I'm not sure whether this has been done by design or whether it's an actual issue, but it'd be great to have this fixed :wink: 
