### PR TITLE
[documentation] Fix the documented default property values

### DIFF
--- a/FBShimmering/FBShimmering.h
+++ b/FBShimmering/FBShimmering.h
@@ -24,16 +24,16 @@ typedef NS_ENUM(NSInteger, FBShimmerDirection) {
 //! @abstract The time interval between shimmerings in seconds. Defaults to 0.4.
 @property (assign, nonatomic, readwrite) CFTimeInterval shimmeringPauseDuration;
 
-//! @abstract The opacity of the content while it is shimmering. Defaults to 1.0.
+//! @abstract The opacity of the content while it is shimmering. Defaults to 0.5.
 @property (assign, nonatomic, readwrite) CGFloat shimmeringAnimationOpacity;
 
-//! @abstract The opacity of the content before it is shimmering. Defaults to 0.5.
+//! @abstract The opacity of the content before it is shimmering. Defaults to 1.0.
 @property (assign, nonatomic, readwrite) CGFloat shimmeringOpacity;
 
 //! @abstract The speed of shimmering, in points per second. Defaults to 230.
 @property (assign, nonatomic, readwrite) CGFloat shimmeringSpeed;
 
-//! @abstract The highlight length of shimmering. Range of [0,1], defaults to 0.33.
+//! @abstract The highlight length of shimmering. Range of [0,1], defaults to 1.0.
 @property (assign, nonatomic, readwrite) CGFloat shimmeringHighlightLength;
 
 //! @abstract @deprecated Same as "shimmeringHighlightLength", just for downward compatibility


### PR DESCRIPTION
The documented default property values are inconsistent with the default configuration in the `- init` method of `FBShimmeringLayer.m`. This simply corrects the doc comments.