### PR TITLE
[Shimmer] fix shimmering speed doesn't update when frame change

### DIFF
--- a/FBShimmering/FBShimmeringLayer.m
+++ b/FBShimmering/FBShimmeringLayer.m
@@ -269,9 +269,10 @@ static CAAnimation *shimmer_slide_finish(CAAnimation *a)
 
 - (void)setBounds:(CGRect)bounds
 {
+  CGRect oldBounds = bounds;
   [super setBounds:bounds];
  
-  if (!CGRectEqualToRect(self.bounds, bounds)) {
+  if (!CGRectEqualToRect(oldBounds, bounds)) {
     [self _updateShimmering];
   }
 }


### PR DESCRIPTION
the if condition is always true, and that causes us never update the shimmering speed.