### PR TITLE
Fix shimmeringHighlightWidth documentation and deprecation attribute

### DIFF
--- a/FBShimmering/FBShimmering.h
+++ b/FBShimmering/FBShimmering.h
@@ -39,8 +39,8 @@ static const float FBShimmerDefaultBeginTime = CGFLOAT_MAX;
 //! @abstract The highlight length of shimmering. Range of [0,1], defaults to 1.0.
 @property (assign, nonatomic, readwrite) CGFloat shimmeringHighlightLength;
 
-//! @abstract @deprecated Same as "shimmeringHighlightLength", just for downward compatibility
-@property (assign, nonatomic, readwrite, getter = shimmeringHighlightLength, setter = setShimmeringHighlightLength:) CGFloat shimmeringHighlightWidth;
+//! @abstract Same as "shimmeringHighlightLength", just for downward compatibility @deprecated
+@property (assign, nonatomic, readwrite, getter = shimmeringHighlightLength, setter = setShimmeringHighlightLength:) CGFloat shimmeringHighlightWidth DEPRECATED_MSG_ATTRIBUTE("Use shimmeringHighlightLength");
 
 //! @abstract The direction of shimmering animation. Defaults to FBShimmerDirectionRight.
 @property (assign, nonatomic, readwrite) FBShimmerDirection shimmeringDirection;


### PR DESCRIPTION
The property `shimmeringHighlightWidth` is causing 2 warnings with strict compiler flags.

The first one is because placing `@deprecated` right after `@abstract` in the documentation comment block causes the parser to think the `@abstract` is empty.
This is fixed by moving `@deprecated` at the end of the comment block.

The second is caused by the method being documented as `@deprecated` but not marked as such with a compiler attribute. This is fixed by using the `DEPRECATED_MSG_ATTRIBUTE` macro.
