### PR TITLE
Fix warnings due to API changes in iOS 10, Beta 2

### DIFF
--- a/FBShimmering/FBShimmeringLayer.m
+++ b/FBShimmering/FBShimmeringLayer.m
@@ -119,6 +119,11 @@ static CAAnimation *shimmer_slide_finish(CAAnimation *a)
 @end
 
 @interface FBShimmeringLayer ()
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
+// iOS 10 SDK has CALayerDelegate and CAAnimationDelegate as proper protocols.
+<CALayerDelegate, CAAnimationDelegate>
+#endif
+
 @property (strong, nonatomic) FBShimmeringMaskLayer *maskLayer;
 @end
 


### PR DESCRIPTION
iOS 10, Beta 2 introduced changes to `CALayerDelegate` and
`CAAnimationDelegate`, both of which are now proper protocols instead of
informal ones.

This can be seen in the [API diffs](https://developer.apple.com/library/prerelease/content/releasenotes/General/iOS10APIDiffs/Objective-C/QuartzCore.html).

This PR fixes the warnings by introducing a macro which compiles to
those two delegate protocols when on the iOS 10 SDK but compiles to
a placeholder protocol when using the iOS 9 SDK or below.

Fixes #63.