### PR TITLE
Adding CALayerDelgate in Class FBShimmerLayer interface 

### DIFF
--- a/FBShimmering/FBShimmeringLayer.h
+++ b/FBShimmering/FBShimmeringLayer.h
@@ -14,7 +14,7 @@
 /**
   @abstract Lightweight, generic shimmering layer.
  */
-@interface FBShimmeringLayer : CALayer <FBShimmering>
+@interface FBShimmeringLayer : CALayer <FBShimmering,CALayerDelegate>
 
 //! @abstract The content layer to be shimmered.
 @property (strong, nonatomic) CALayer *contentLayer;


### PR DESCRIPTION
To avoid warnings in XCode 8.3 